### PR TITLE
hide radar pulse line completely when radar pulse is disabled

### DIFF
--- a/Radar/HaloRadar.cs
+++ b/Radar/HaloRadar.cs
@@ -88,8 +88,14 @@ namespace Radar
 
         private void UpdateRadarSettings(object? sender = null, SettingChangedEventArgs? e = null)
         {
+            if (!gameObject.activeInHierarchy) return; // Don't update if the radar object is disabled
+
             _radarPulseInterval = Mathf.Max(1f, Radar.radarScanInterval.Value);
-            TogglePulseAnimation(Radar.radarEnablePulseConfig.Value);
+
+            if (e == null || e.ChangedSetting == Radar.radarEnablePulseConfig)
+            {
+                TogglePulseAnimation(Radar.radarEnablePulseConfig.Value);
+            }
         }
 
         private void TogglePulseAnimation(bool enable)
@@ -101,14 +107,16 @@ namespace Radar
                 {
                     StopCoroutine(_pulseCoroutine);
                 }
-                _pulseCoroutine = StartCoroutine(PulseCoroutine());;
+
+                _pulseCoroutine = StartCoroutine(PulseCoroutine());
             }
             else if (_pulseCoroutine != null && !enable)
             {
                 StopCoroutine(_pulseCoroutine);
                 _pulseCoroutine = null;
-                _radarHudPulse.localEulerAngles = new Vector3(0, 0, 0); // Reset rotation so it doesn't stop in a weird position
             }
+
+            _radarHudPulse.gameObject.SetActive(enable);
         }
 
         private void Update()


### PR DESCRIPTION
Hide the pulse line so the hud is much cleaner with the animation disabled.

Limit the animation reset to only when needed, so you won't see it jumps around when changing other settings

Also fixed a lifecycle issue where it is trying to start the coroutine when the gameobject is still inactive