### PR TITLE
Fixed issue with multiplayer sessions not displaying blips correctly

### DIFF
--- a/Radar/HaloRadar.cs
+++ b/Radar/HaloRadar.cs
@@ -28,7 +28,7 @@ namespace Radar
 
         public static float RadarLastUpdateTime = 0;
 
-        private readonly Dictionary<int, BlipPlayer> _enemyList = new Dictionary<int, BlipPlayer>();
+        private readonly Dictionary<string, BlipPlayer> _enemyList = new Dictionary<string, BlipPlayer>();
 
         private readonly List<BlipLoot> _lootCustomObject = new List<BlipLoot>();
         private Quadtree? _lootTree = null;
@@ -251,7 +251,7 @@ namespace Radar
             }
         }
 
-        public void UpdateFireTime(int id)
+        public void UpdateFireTime(string id)
         {
             if (_enemyList.ContainsKey(id))
             {
@@ -386,9 +386,9 @@ namespace Radar
                 {
                     continue;
                 }
-                if (!_enemyList.ContainsKey(enemyPlayer.Id))
+                if (!_enemyList.ContainsKey(enemyPlayer.ProfileId))
                 {
-                    _enemyList.Add(enemyPlayer.Id, new BlipPlayer(enemyPlayer));
+                    _enemyList.Add(enemyPlayer.ProfileId, new BlipPlayer(enemyPlayer));
                 }
             }
             return 0;

--- a/Radar/PlayerPatch.cs
+++ b/Radar/PlayerPatch.cs
@@ -17,7 +17,7 @@ namespace Radar
         static void PostFix(Player __instance, [NotNull] GInterface322 weapon, Vector3 force)
         {
             var radar = InRaidRadarManager._radarGo.GetComponent<HaloRadar>();
-            radar.UpdateFireTime(__instance.Id);
+            radar.UpdateFireTime(__instance.ProfileId);
         }
     }
 }


### PR DESCRIPTION
The source of the problem here lies in the fact that Player.Id isn't guaranteed to be unique when running Fika - mods can generate their own bots, each of which can have duplicate IDs. I don't think the same is ever true for a profile Id, so this should handle it. There's a slight downside of performance, but because of the caching here, I don't expect major performance concerns (and didn't notice any in my testing). 

A few things I noticed while I was poking around:
- There are quite a few compiler warnings around null handling. Some of this is just because of the way Unity handles instantiating things - fields are not set in constructors. I can make a PR for this if you want to get rid of the warnings. I didn't see any actual null reference concerns, though.
- There's an issue with the new flea market price option - it's relying on another mod (live flea market prices, maybe?). That endpoint doesn't exist in SPT by default. It may be worthwhile to conditionally check flea prices depending on whether that mod is present.
- I think you may have fixed this in a recent commit, but something is broken around persisting the loot radar setting.