### PR TITLE
feat: add height differentiation for corpses

### DIFF
--- a/Radar/Blips.cs
+++ b/Radar/Blips.cs
@@ -19,14 +19,27 @@ namespace Radar
         private void UpdateBlipImage()
         {
             if (blip == null || blipImage == null) return;
+            // set threshold for height difference
+            float totalThreshold = playerHeight * 1.2f * Radar.radarYHeightThreshold.Value;
             if (_isDead)
             {
-                blipImage.sprite = AssetBundleManager.EnemyBlipDead;
+                // set blip image for corpses
+                if (Mathf.Abs(blipPosition.y) <= totalThreshold)
+                {
+                    blipImage.sprite = AssetBundleManager.EnemyBlipDead;
+                }
+                else if (blipPosition.y > totalThreshold)
+                {
+                    blipImage.sprite = AssetBundleManager.EnemyBlipUp;
+                }
+                else if (blipPosition.y < -totalThreshold)
+                {
+                    blipImage.sprite = AssetBundleManager.EnemyBlipDown;
+                }
                 blipImage.color = Radar.corpseBlipColor.Value;
             }
             else
             {
-                float totalThreshold = playerHeight * 1.5f * Radar.radarYHeightThreshold.Value;
                 if (Mathf.Abs(blipPosition.y) <= totalThreshold)
                 {
                     blipImage.sprite = AssetBundleManager.EnemyBlip;
@@ -91,7 +104,7 @@ namespace Radar
 
                 var distance = blipPosition.x * blipPosition.x + blipPosition.z * blipPosition.z;
                 _show = (distance > radarOuterRange * radarOuterRange || distance < radarInnerRange * radarInnerRange) ? false : true;
-                
+
                 if (!_isDead && _enemyPlayer.HealthController.IsAlive == _isDead)
                 {
                     _isDead = true;
@@ -140,7 +153,7 @@ namespace Radar
         {
             if (blip == null || blipImage == null)
                 return;
-            float totalThreshold = playerHeight * 1.5f * Radar.radarYHeightThreshold.Value;
+            float totalThreshold = playerHeight * 1.2f * Radar.radarYHeightThreshold.Value;
             if (blipPosition.y > totalThreshold)
             {
                 blipImage.sprite = AssetBundleManager.EnemyBlipUp;
@@ -148,7 +161,8 @@ namespace Radar
             else if (blipPosition.y < -totalThreshold)
             {
                 blipImage.sprite = AssetBundleManager.EnemyBlipDown;
-            } else
+            }
+            else
             {
                 blipImage.sprite = AssetBundleManager.EnemyBlipDead;
             }


### PR DESCRIPTION
This PR adds height differentiation for corpses on the radar.

Also slightly reduces the base multiplier for blip selection; I've found this to be a bit more accurate.

This is a cleaned up version of [PR 5](https://github.com/Leonana69/Tyrian-Radar-Standalone/pull/5) which had some old code in the included commits (will just be a cleaner commit history).