### PR TITLE
fix: loot blips not disappearing when out of radar range

### DIFF
--- a/Radar/Blips.cs
+++ b/Radar/Blips.cs
@@ -169,6 +169,9 @@ namespace Radar
             blipPosition.y = targetPosition.y - playerPosition.y;
             blipPosition.z = targetPosition.z - playerPosition.z;
 
+            var distance = blipPosition.x * blipPosition.x + blipPosition.z * blipPosition.z;
+            _show = (distance > radarOuterRange * radarOuterRange || distance < radarInnerRange * radarInnerRange) ? false : true;
+                
             if (!_show)
             {
                 if (blipImage != null)


### PR DESCRIPTION
Adds a distance check for loot blips, as is done with NPC blips.